### PR TITLE
Change to using version 3.31 of the SDK

### DIFF
--- a/google-sdk-v3/nearmap.html
+++ b/google-sdk-v3/nearmap.html
@@ -30,7 +30,7 @@
           padding-right: 5px;
       }
     </style>
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&sensor=false"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.31&sensor=false"></script>
     <script src="nearmap.js"></script>
   </head>
   <body>


### PR DESCRIPTION
We received reports that the sample doesn't work for E and W orientations. We investigated and found that this only happens in the experimental version of the SDK. Reverting to stable now.