### PR TITLE
Workaround for recent changes in Google Maps SDK (v3.32)

### DIFF
--- a/google-sdk-v3/nearmap.js
+++ b/google-sdk-v3/nearmap.js
@@ -5,229 +5,291 @@ var austin = new google.maps.LatLng(30.2746378,-97.7403547);
 // Create your own API as per https://support.nearmap.com/hc/en-us/articles/115006379787-API-Key-Authentication
 var apikey = 'ZjNhZDkyNDUtZjIyMS00NTkwLWJlMzYtZDJlNWUyNDkxNjE4';
 
+
 function degreesToRadians(deg) {
-	return deg * (Math.PI / 180);
+  return deg * (Math.PI / 180);
 }
 
 function radiansToDegrees(rad) {
-	return rad / (Math.PI / 180);
+  return rad / (Math.PI / 180);
 }
 
-function rotateLatLng(latlng, heading){
-	var lat = latlng.lat();
-	var lng = latlng.lng();
 
-	switch(heading){
-		case 0:
-			break;
-		case 90:
-			lng = -lng;
-			break;
-		case 180:
-			lat = -lat;
-			lng = -lng;
-			break;
-		case 270:
-			lat = -lat;
-			break;
-	}
-	return new google.maps.LatLng(lat, lng);
+/**
+ * Return the region from which to load a tile.
+ * Convert coordinate to a zoom level 1 and return
+ * 'us' if it happens to be in the top left corner of the world
+ */
+function regionForCoordinate(x, y, zoom) {
+  var x_z1 = x / Math.pow(2, (zoom - 1));
+  if (x_z1 < 1) {
+      return 'us';
+  } else {
+      return 'au';
+  }
 }
 
-function rotatePoint(point, heading){
-	if(heading === 0 || heading === 180){
-		return new google.maps.Point(point.x, point.y);
-	}else{
-		return new google.maps.Point(point.y, point.x);
-	}
+
+/**
+ * Calculate the true tile coordinate for a given google maps `coord`, `zoom`
+ * and `heading`.
+ *
+ * Nearmap tiles are layed out as follow:
+ * ```
+ *   Vert/North       East          South          West
+ * -------------  -------------  -------------  -------------
+ * | 0,0 | 1,0 |  | 1,0 | 1,1 |  | 1,1 | 0,1 |  | 0,1 | 0,0 |
+ * |-----|-----|  |-----|-----|  |-----|-----|  |-----|-----|
+ * | 0,1 | 1,1 |  | 0,0 | 0,1 |  | 1,0 | 0,0 |  | 1,1 | 1,0 |
+ * -------------  -------------  -------------  -------------
+ *```
+ * Depending on the heading the tile coordinates are simply rotated
+ * around the center of the fully tiled map at the given zoom level.
+ */
+function rotateTile(coord, zoom, heading) {
+  var numTiles = 1 << zoom; // 2^zoom
+  var x, y;
+
+  switch(heading){
+    case 0:
+      x = coord.x;
+      y = coord.y;
+      break;
+    case 90:
+      x = numTiles - (coord.y + 1);
+      y = coord.x;
+      break;
+    case 180:
+      x = numTiles - (coord.x + 1);
+      y = numTiles - (coord.y + 1);
+      break;
+    case 270:
+      x = coord.y;
+      y = numTiles - (coord.x + 1);
+      break;
+  }
+  return new google.maps.Point(x, y);
 }
 
-//return the region from which to load a tile.
-//convert coordinate to a zoom level 1 and return us if it happens to be in the
-//top left corner of the world
-function regionForCoordinate(x,y,zoom) {
-    var x_z1 = x/Math.pow(2,(zoom - 1));
-    if (x_z1 < 1) {
-        return 'us';
-    } else {
-        return 'au';
-    }
+
+/**
+* A Mercator like projection that allows for non square world coordinates
+* given the `worldWidth` `worldHeight`.
+*
+* see https://developers.google.com/maps/documentation/javascript/maptypes#Projections
+*/
+function MercatorProjection(worldWidth, worldHeight){
+  this.pixelOrigin = new google.maps.Point(worldWidth / 2, worldHeight / 2);
+  this.pixelsPerLonDegree = worldWidth / 360;
+  this.pixelsPerLatRadian = worldHeight / (2 * Math.PI);
 }
-
-function MercatorProjection(tileWidth, tileHeight, heading){
-	this.heading = heading;
-
-	this.pixelOrigin = new google.maps.Point(
-		tileWidth / 2, tileHeight / 2);
-
-	if(heading === 0 || heading === 180){
-		this.pixelsPerLonDegree = tileWidth / 360;
-		this.pixelsPerLatRadian = tileHeight / (2 * Math.PI);
-	}else{
-		this.pixelsPerLonDegree = tileHeight / 360;
-		this.pixelsPerLatRadian = tileWidth / (2 * Math.PI);
-	}
-};
 
 MercatorProjection.prototype.fromLatLngToPoint=function(latlng, opt_point) {
-	var point = opt_point || new google.maps.Point(0, 0);
+  var point = opt_point || new google.maps.Point(0, 0);
+  var origin = this.pixelOrigin;
 
-	var origin = rotatePoint(this.pixelOrigin, this.heading);
-	latlng = rotateLatLng(latlng, this.heading);
+  var lat = latlng.lat();
+  var lng = latlng.lng();
 
-	var lat = latlng.lat();
-	var lng = latlng.lng();
+  point.x = origin.x + lng * this.pixelsPerLonDegree;
+  var siny = Math.sin(degreesToRadians(lat));
+  point.y = origin.y + 0.5 * Math.log((1 + siny) / (1 - siny)) *
+    -this.pixelsPerLatRadian;
 
-	point.x = origin.x + lng * this.pixelsPerLonDegree;
-
-	var siny = Math.sin(degreesToRadians(lat));
-	point.y = origin.y + 0.5 * Math.log((1 + siny) / (1 - siny)) *
-		-this.pixelsPerLatRadian;
-
-	return rotatePoint(point, this.heading);
+  return point;
 };
 
 MercatorProjection.prototype.fromPointToLatLng = function(point, noWrap) {
-	var origin = rotatePoint(this.pixelOrigin, this.heading);
-	point = rotatePoint(point, this.heading);
+  var origin = this.pixelOrigin;
 
-	var lng = (point.x - origin.x) / this.pixelsPerLonDegree;
-	var latRadians = (point.y - origin.y) / -this.pixelsPerLatRadian;
-	var lat = radiansToDegrees(2 * Math.atan(Math.exp(latRadians)) -
-		Math.PI / 2);
+  var lng = (point.x - origin.x) / this.pixelsPerLonDegree;
+  var latRadians = (point.y - origin.y) / -this.pixelsPerLatRadian;
+  var lat = radiansToDegrees(2 * Math.atan(Math.exp(latRadians)) - Math.PI / 2);
 
-	return rotateLatLng(new google.maps.LatLng(lat, lng), this.heading);
+  return new google.maps.LatLng(lat, lng);
 };
 
-function createMapType(tileWidth, tileHeight, heading, name){
 
-	var maptype = new google.maps.ImageMapType({
-		getTileUrl: function(coord, zoom) {
-			var numTiles = 1 << zoom;
+const projVertical = new MercatorProjection(256, 256);
 
-			switch(heading){
-				case 90:
-					coord = new google.maps.Point(
-						numTiles - (coord.y + 1),
-						coord.x
-					);
-					break;
-				case 180:
-					coord = new google.maps.Point(
-						numTiles - (coord.x + 1),
-						numTiles - (coord.y + 1)
-					);
-					break;
-				case 270:
-					coord = new google.maps.Point(
-						coord.y,
-						numTiles - (coord.x + 1)
-					);
-            }
-
-
-			var x = coord.x;
-			var y = coord.y;
-			var url = 'http://'+
-                regionForCoordinate(x,y,zoom) + 
-                '0.nearmap.com/maps/hl=en' +
-				'&x=' + x +
-				'&y=' + y +
-				'&z=' + zoom +
-				'&nml=' + name + '&httpauth=false&version=2' +
-                '&apikey=' + apikey;
-			return url;
-		},
-		tileSize: new google.maps.Size(tileWidth, tileHeight),
-		isPng: true,
-		minZoom: 1,
-		maxZoom: 24,
-		name: name
-	});
-	maptype.projection = new MercatorProjection(
-			tileWidth, tileHeight, heading);
-	return maptype;
+function vertToWest(ll) {
+  var pt = projVertical.fromLatLngToPoint(ll);
+  pt = new google.maps.Point(pt.y, pt.x);
+  ll = projVertical.fromPointToLatLng(pt);
+  return new google.maps.LatLng(ll.lat(), -ll.lng());
 }
 
-function createBookmarkControl(map) {
-	// Create the DIV to hold the control and call the bookmarkControl()
-    // constructor passing in this DIV.
-    var bookmarkControlDiv = document.createElement('div');
-    var bookmarkControl = new BookmarkControl(bookmarkControlDiv, map);
+function westToVert(ll) {
+  ll = new google.maps.LatLng(ll.lat(), -ll.lng());
+  var pt = projVertical.fromLatLngToPoint(ll);
+  pt = new google.maps.Point(pt.y, pt.x);
+  return projVertical.fromPointToLatLng(pt);
+}
 
-    bookmarkControlDiv.index = 1;
-    map.controls[google.maps.ControlPosition.TOP_CENTER].push(bookmarkControlDiv);
+function vertToEast(ll) {
+  var pt = projVertical.fromLatLngToPoint(ll);
+  pt = new google.maps.Point(pt.y, pt.x);
+  ll = projVertical.fromPointToLatLng(pt);
+  return new google.maps.LatLng(-ll.lat(), ll.lng());
+}
+
+function eastToVert(ll) {
+	ll = new google.maps.LatLng(-ll.lat(), ll.lng());
+  var pt = projVertical.fromLatLngToPoint(ll);
+  pt = new google.maps.Point(pt.y, pt.x);
+  return projVertical.fromPointToLatLng(pt);
 }
 
 /**
-* The BookmarkControl adds a control to the map that has two bookmarks for 
+ * Convert a `ll` top a fake LatLng for a map using
+ * any of the obliquie base-layers with the given `mapTypeId`.
+ */
+function fakeLatLng(mapTypeId, ll) {
+  if (mapTypeId === 'W') {
+    ll = vertToWest(ll);
+  } else if (mapTypeId === 'E') {
+    ll = vertToEast(ll);
+  } else if (mapTypeId === 'S') {
+    ll = new google.maps.LatLng(-ll.lat(), -ll.lng());
+  }
+  return ll;
+}
+
+/**
+ * Convert a fake `ll` to a reaal LatLng for a map using
+ * any of the obliquie base-layers with the given `mapTypeId`.
+ */
+function realLatLng(mapTypeId, ll) {
+  if (mapTypeId === 'W') {
+    ll = westToVert(ll);
+  } else if (mapTypeId === 'E') {
+    ll = eastToVert(ll);
+  } else if (mapTypeId === 'S') {
+    ll = new google.maps.LatLng(-ll.lat(), -ll.lng());
+  }
+  return ll;
+}
+
+/**
+ * Install a base-layer change handler to update the `map`'s center so that
+ * the new base-layer shows the same geographic location as the previous layer.
+ */
+function registerProjectionWorkaround(map) {
+	var currMapType = map.getMapTypeId();
+
+  map.addListener('maptypeid_changed', function() {
+    var center = realLatLng(currMapType, map.getCenter());
+    currMapType = map.getMapTypeId();
+    map.setCenter(fakeLatLng(currMapType, center));
+  });
+}
+
+
+function createMapType(tileWidth, tileHeight, heading, name){
+  var maptype = new google.maps.ImageMapType({
+    name: name,
+    tileSize: new google.maps.Size(tileWidth, tileHeight),
+    isPng: true,
+    minZoom: 1,
+    maxZoom: 24,
+    getTileUrl: function(coord, zoom) {
+      coord = rotateTile(coord, zoom, heading);
+
+      var x = coord.x;
+      var y = coord.y;
+      var url = 'http://'+ regionForCoordinate(x, y, zoom) +
+        '0.nearmap.com/maps/hl=en' +
+        '&x=' + x +
+        '&y=' + y +
+        '&z=' + zoom +
+        '&nml=' + name + '&httpauth=false&version=2' +
+        '&apikey=' + apikey;
+      return url;
+    }
+  });
+  maptype.projection = new MercatorProjection(tileWidth, tileHeight);
+  return maptype;
+}
+
+function createBookmarkControl(map) {
+  // Create the DIV to hold the control and call the bookmarkControl()
+  // constructor passing in this DIV.
+  var bookmarkControlDiv = document.createElement('div');
+  var bookmarkControl = new BookmarkControl(bookmarkControlDiv, map);
+
+  bookmarkControlDiv.index = 1;
+  map.controls[google.maps.ControlPosition.TOP_CENTER].push(bookmarkControlDiv);
+}
+
+/**
+* The BookmarkControl adds a control to the map that has two bookmarks for
 * the Nearmap demo areas
 * This constructor takes the control DIV as an argument.
 * @constructor
 */
 function BookmarkControl(controlDiv, map) {
 
-	/**
-	 * Create an actual control HTML element and add an event listener that centers the map
-	 * on a point provided by the point argument
-	 */
-	function createBookmarkLink(label, point){
-		var bookmarkLink = document.createElement('span');
-		bookmarkLink.className = 'bookmark-link';
-		bookmarkLink.innerHTML = label;
+  /**
+   * Create an actual control HTML element and add an event listener that centers the map
+   * on a point provided by the point argument
+   */
+  function createBookmarkLink(label, point){
+    var bookmarkLink = document.createElement('span');
+    bookmarkLink.className = 'bookmark-link';
+    bookmarkLink.innerHTML = label;
 
-		bookmarkLink.addEventListener('click', function() {
-		  map.setCenter(point);
-		});
+    bookmarkLink.addEventListener('click', function() {
+			 // To ensure that the correct imagery is shown we need to
+			 // get a fake LatLng for E+S+W oblique imagery.
+       map.setCenter(fakeLatLng(map.getMapTypeId(), point));
+    });
 
-		return bookmarkLink;
-	}
+    return bookmarkLink;
+  }
 
+  // Set CSS for the control border.
+  var bookmarkContainer = document.createElement('div');
+  bookmarkContainer.className = 'bookmark-container';
+  controlDiv.appendChild(bookmarkContainer);
 
-	// Set CSS for the control border.
-	var bookmarkContainer = document.createElement('div');
-	bookmarkContainer.className = 'bookmark-container';
-	controlDiv.appendChild(bookmarkContainer);
-
-
-	bookmarkContainer.appendChild(createBookmarkLink('Australia', adelaide));
-	bookmarkContainer.appendChild(createBookmarkLink('USA', austin));
-
+  bookmarkContainer.appendChild(createBookmarkLink('Australia', adelaide));
+  bookmarkContainer.appendChild(createBookmarkLink('USA', austin));
 }
 
+
 function initialize() {
+  if (apikey === undefined || apikey.length === 0) {
+    alert('Please provide your Nearmap API Key');
+    return;
+  }
 
+  var map_types=[
+    createMapType(256, 256, 0, 'Vert'),
+    createMapType(256, 181, 0, 'N'),
+    createMapType(256, 181, 90, 'E'),
+    createMapType(256, 181, 180, 'S'),
+    createMapType(256, 181, 270, 'W'),
+  ];
 
-	if (apikey === undefined || apikey.length === 0) {
-		alert('Please provide your Nearmap API Key');
-		return;
-	}
+  var mapOptions = {
+    zoom: 19,
+    center: adelaide,
+    mapTypeControlOptions: {
+      mapTypeIds: [google.maps.MapTypeId.ROADMAP, 'Vert', 'N', 'E', 'S', 'W']
+    }
+  };
+  var map = new google.maps.Map(document.getElementById('map'), mapOptions);
 
-	var map_types=[
-		createMapType(256, 256, 0, 'Vert'),
-		createMapType(256, 181, 0, 'N'),
-		createMapType(256, 181, 90, 'E'),
-		createMapType(256, 181, 180, 'S'),
-		createMapType(256, 181, 270, 'W'),
-	];
+  for(var i=0; i<map_types.length; i++){
+    var mt = map_types[i];
+    map.mapTypes.set(mt.name, mt);
+  }
 
-	var mapOptions = {
-		zoom: 19,
-		center: adelaide,
-		mapTypeControlOptions: {
-			mapTypeIds: [google.maps.MapTypeId.ROADMAP, 'Vert', 'N', 'E', 'S', 'W']
-		}
-	};
-	var map = new google.maps.Map(document.getElementById('map'), mapOptions);
+	registerProjectionWorkaround(map);
 
-	for(var i=0; i<map_types.length;i++){
-		var mt = map_types[i];
-		map.mapTypes.set(mt.name, mt);
-	}
+  map.setMapTypeId('Vert');
 
-	map.setMapTypeId('Vert');
-
-	createBookmarkControl(map);
+  createBookmarkControl(map);
 }
 
 google.maps.event.addDomListener(window, 'load', initialize);


### PR DESCRIPTION
* Updated projections to conform with the SDK's requirements. 
* Added workarounds to be able to display E/S/W tile layers and transparently switch between them.

Google's recent changes restricts the way custom projections can work. 
This causes issues when trying to work with E/S/W tile layers.

To work around these limitations we use a custom projection that only scales the world's height to simulate an oblique perspective. This is how the projection for N tiles has always worked.

Unfortunately we cannot rotate the map to have E/S/W at the top and we cannot fully implement a projection which would rotate the coordinate system as we have been doing for E/S/W tile layers.

Instead we use the the same projection as for N, and during tile loading we simply recalculate the tile coordinate by rotating their coordinate system.

This will load and display our tiles and allow users to navigate them but when using any of the E/S/W layers the imagery is not shown in the correct geographic location. We can work around that by projecting a real `lat,lng` to world coordinates, rotating them based on the layers's heading and projecting these back  into a fake `lat,lng` that we can use to e.g. update the map's center when switching between the layers.